### PR TITLE
modify the validation of 1D detonation

### DIFF
--- a/test/corrtest.cpp
+++ b/test/corrtest.cpp
@@ -44,7 +44,7 @@ TEST(corrtest,dfLowMachFoam_TGV){
 }
 
 TEST(corrtest,dfHighSpeedFoam){
-    EXPECT_FLOAT_EQ(v,1993.38);
+    EXPECT_NEAR(v,1979.33,19.79);
 }
 
 


### PR DESCRIPTION
The validation method is changed to check if the result is within 1% of the theoretical value.