### PR TITLE
add option to source bashrc automatically

### DIFF
--- a/docs/source/qs/install.rst
+++ b/docs/source/qs/install.rst
@@ -55,25 +55,19 @@ If you compiled from source following the `official guide <https://openfoam.org/
 
     source $HOME/OpenFOAM/OpenFOAM-7/etc/bashrc
 
-To source the bashrc file automatically when opening your terminal, open the .bashrc file in the user’s home directory in an editor, e.g. by typing in a terminal window
+To source the bashrc file automatically when opening your terminal, type
 
 .. code-block:: bash
 
-    vim ~/.bashrc
-
-copy 
-
-.. code-block:: bash
-
-    source /opt/openfoam7/etc/bashrc 
+    echo "source /opt/openfoam7/etc/bashrc" >> ~/.bashrc
 
 or
 
 .. code-block:: bash
 
-    source $HOME/OpenFOAM/OpenFOAM-7/etc/bashrc
+     echo "source $HOME/OpenFOAM/OpenFOAM-7/etc/bashrc" >> ~/.bashrc
     
-to the end of ~/.bashrc file and save it. Then source the bashrc file by:
+Then source the bashrc file by:
 
 .. code-block:: bash
 

--- a/docs/source/qs/install.rst
+++ b/docs/source/qs/install.rst
@@ -48,12 +48,36 @@ If you have installed using ``apt-get install``, then:
 .. code-block:: bash
 
     source /opt/openfoam7/etc/bashrc 
-    
+
 If you compiled from source following the `official guide <https://openfoam.org/download/7-source/>`_, then:
 
 .. code-block:: bash
 
     source $HOME/OpenFOAM/OpenFOAM-7/etc/bashrc
+
+To source the bashrc file automatically when opening your terminal, open the .bashrc file in the user’s home directory in an editor, e.g. by typing in a terminal window
+
+.. code-block:: bash
+
+    vim ~/.bashrc
+
+copy 
+
+.. code-block:: bash
+
+    source /opt/openfoam7/etc/bashrc 
+
+or
+
+.. code-block:: bash
+
+    source $HOME/OpenFOAM/OpenFOAM-7/etc/bashrc
+    
+to the end of ~/.bashrc file and save it. Then source the bashrc file by:
+
+.. code-block:: bash
+
+    source ~/.bashrc
 
 .. Note:: Check your environment using ``echo $FOAM_ETC`` and you should get the directory path for your OpenFOAM-7 bashrc you just used in the above step.
 


### PR DESCRIPTION
By adding the source command to ~/.bashrc file, bashrc of OpenFOAM can be included automatically when opening a terminal.