### PR TITLE
Add support for python version agnostic building

### DIFF
--- a/applications/solvers/df0DFoam/CMakeLists.txt
+++ b/applications/solvers/df0DFoam/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DEFINED ENV{CANTERA_ROOT})
   SET(CANTERA_ROOT $ENV{CANTERA_ROOT})
 else()
 	message(FATAL_ERROR "libcantera directory is not specified")
-endif(DEFINED ENV{CANTERA_ROOT}) 
+endif(DEFINED ENV{CANTERA_ROOT})
 
 # define variables
 SET(OpenFOAM_LIB_DIR $ENV{FOAM_LIBBIN})
@@ -29,11 +29,11 @@ SET(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=bfd -Xlinker --add-needed -Xlinker --no-as-
 
 SET(CMAKE_C_COMPILER g++)
 SET(PATH_LIB_OPENMPI "openmpi-system")  # Foundation version
-SET(EXE_COMPILE_OPTION "-std=c++11 -m64 -Dlinux64 -DWM_ARCH_OPTION=64 
--DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor 
--Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3  
--DNoRepository -ftemplate-depth-100 -std=c++14 
--Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX  
+SET(EXE_COMPILE_OPTION "-std=c++17 -m64 -Dlinux64 -DWM_ARCH_OPTION=64
+-DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor
+-Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3
+-DNoRepository -ftemplate-depth-100
+-Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX
 -pthread -fPIC")
 add_definitions("${EXE_COMPILE_OPTION}")
 
@@ -47,7 +47,7 @@ FUNCTION(R_SEARCH search_path return_list)
     ENDFOREACH()
     LIST(REMOVE_DUPLICATES dir_list)
     SET(${return_list} ${dir_list} PARENT_SCOPE)
-ENDFUNCTION(R_SEARCH)  
+ENDFUNCTION(R_SEARCH)
 
 R_SEARCH(${DF_SRC}/dfCombustionModels dfcombustion_inc)
 R_SEARCH(${DF_SRC}/dfCanteraMixture dfcantera_inc)
@@ -67,31 +67,30 @@ include_directories(
     ${OpenFOAM_SRC}/finiteVolume/lnInclude
     ${OpenFOAM_SRC}/OSspecific/POSIX/lnInclude
     ${OpenFOAM_SRC}/OpenFOAM/lnInclude
-    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/finiteVolume/cfdTools 
-    ${OpenFOAM_SRC}/finiteVolume/lnInclude 
-    ${OpenFOAM_SRC}/meshTools/lnInclude 
-    ${OpenFOAM_SRC}/sampling/lnInclude 
-    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude 
-    ${OpenFOAM_SRC}/Pstream/mpi 
+    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/finiteVolume/cfdTools
+    ${OpenFOAM_SRC}/finiteVolume/lnInclude
+    ${OpenFOAM_SRC}/meshTools/lnInclude
+    ${OpenFOAM_SRC}/sampling/lnInclude
+    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude
+    ${OpenFOAM_SRC}/Pstream/mpi
     ${dfcantera_inc}
     ${dfchemistry_inc}
     ${dfcombustion_inc}
-    ${CANTERA_ROOT}/include 
+    ${CANTERA_ROOT}/include
     ${MPI_INCLUDE_PATH}
     ${PROJECT_SOURCE_DIR}
 )
 
 # add execution
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/df0DFoam.C)
-
-target_link_libraries(${PROJECT_NAME} 
-    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so 
+target_link_libraries(${PROJECT_NAME}
+    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so
     libturbulenceModels.so libsampling.so libOpenFOAM.so libdynamicFvMesh.so
-    ${CANTERA_ROOT}/lib/libcantera.so.2
+    ${CANTERA_ROOT}/lib/libcantera.so
     ${DF_ROOT}/lib/libdfChemistryModel.so
     ${DF_ROOT}/lib/libdfCanteraMixture.so
     ${DF_ROOT}/lib/libdfFluidThermophysicalModels.so
@@ -102,14 +101,9 @@ target_link_libraries(${PROJECT_NAME}
 
 if(DEFINED ENV{PYTHON_INC_DIR})
   add_definitions(-DUSE_PYTORCH)
-  find_package (Python REQUIRED COMPONENTS Interpreter Development)
+  # https://pybind11.readthedocs.io/en/stable/advanced/embedding.html
   find_package(pybind11)
-  include_directories(
-  ${Python_INCLUDE_DIRS}
-  ${pybind11_INCLUDE_DIR}/pybind11
-  )
-  target_link_libraries(${PROJECT_NAME} ${Python_LIBRARIES})
-  message(STATUS "pybind libraries" ${Python_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME} pybind11::embed)
 endif()
 
 # install

--- a/applications/solvers/df0DFoam/Make/options
+++ b/applications/solvers/df0DFoam/Make/options
@@ -7,19 +7,19 @@ EXE_INC = -std=c++17 \
     $(PFLAGS) $(PINC) \
     $(if $(LIBTORCH_ROOT),-DUSE_LIBTORCH,) \
     $(if $(PYTHON_INC_DIR),-DUSE_PYTORCH,) \
-    -I$(LIB_SRC)/transportModels/compressible/lnInclude \
-    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
+    -I$(CANTERA_ROOT)/include \
+    -I$(DF_SRC)/dfCanteraMixture/lnInclude \
+    -I$(DF_SRC)/dfChemistryModel/lnInclude \
+    -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
     -I$(LIB_SRC)/finiteVolume/cfdTools \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/sampling/lnInclude \
     -I$(LIB_SRC)/Pstream/mpi \
-    -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
-    -I$(DF_SRC)/dfCanteraMixture/lnInclude \
-    -I$(DF_SRC)/dfChemistryModel/lnInclude \
-    -I$(CANTERA_ROOT)/include \
+    -I$(LIB_SRC)/sampling/lnInclude \
+    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
+    -I$(LIB_SRC)/transportModels/compressible/lnInclude \
+    -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
+    -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     $(if $(LIBTORCH_ROOT),-I$(LIBTORCH_ROOT)/include,) \
     $(if $(LIBTORCH_ROOT),-I$(LIBTORCH_ROOT)/include/torch/csrc/api/include,) \
     $(if $(BOOST_ARCH_PATH),-I$(BOOST_ARCH_PATH),) \
@@ -47,5 +47,4 @@ EXE_LIBS = \
     $(if $(LIBTORCH_ROOT),-rdynamic,) \
     $(if $(LIBTORCH_ROOT),-lpthread,) \
     $(if $(LIBTORCH_ROOT),$(DF_SRC)/dfChemistryModel/DNNInferencer/build/libDNNInferencer.so,) \
-    $(if $(PYTHON_LIB_DIR),-L$(PYTHON_LIB_DIR),) \
-    $(if $(PYTHON_LIB_DIR),-lpython3.8,)
+    $(if $(PYTHON_LIB_DIR),$(PYTHON_LIB_DIR),)

--- a/applications/solvers/dfHighSpeedFoam/CMakeLists.txt
+++ b/applications/solvers/dfHighSpeedFoam/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DEFINED ENV{CANTERA_ROOT})
   SET(CANTERA_ROOT $ENV{CANTERA_ROOT})
 else()
 	message(FATAL_ERROR "libcantera directory is not specified")
-endif(DEFINED ENV{CANTERA_ROOT}) 
+endif(DEFINED ENV{CANTERA_ROOT})
 
 # define variables
 SET(OpenFOAM_LIB_DIR $ENV{FOAM_LIBBIN})
@@ -29,11 +29,11 @@ SET(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=bfd -Xlinker --add-needed -Xlinker --no-as-
 
 SET(CMAKE_C_COMPILER g++)
 SET(PATH_LIB_OPENMPI "openmpi-system")  # Foundation version
-SET(EXE_COMPILE_OPTION "-std=c++11 -m64 -Dlinux64 -DWM_ARCH_OPTION=64 
--DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor 
--Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3  
--DNoRepository -ftemplate-depth-100 -std=c++14 
--Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX  
+SET(EXE_COMPILE_OPTION "-std=c++17 -m64 -Dlinux64 -DWM_ARCH_OPTION=64
+-DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor
+-Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3
+-DNoRepository -ftemplate-depth-100
+-Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX
 -pthread -fPIC")
 add_definitions("${EXE_COMPILE_OPTION}")
 
@@ -67,21 +67,21 @@ include_directories(
     ${OpenFOAM_SRC}/finiteVolume/lnInclude
     ${OpenFOAM_SRC}/OSspecific/POSIX/lnInclude
     ${OpenFOAM_SRC}/OpenFOAM/lnInclude
-    $ENV{FOAM_APP}/solvers/compressible/rhoCentralFoam/BCs/lnInclude 
-    ${OpenFOAM_SRC}/finiteVolume/cfdTools 
-    ${OpenFOAM_SRC}/finiteVolume/lnInclude 
-    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/sampling/lnInclude 
-    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude 
-    ${OpenFOAM_SRC}/Pstream/mpi 
-    ${OpenFOAM_SRC}/meshTools/lnInclude 
+    $ENV{FOAM_APP}/solvers/compressible/rhoCentralFoam/BCs/lnInclude
+    ${OpenFOAM_SRC}/finiteVolume/cfdTools
+    ${OpenFOAM_SRC}/finiteVolume/lnInclude
+    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/sampling/lnInclude
+    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude
+    ${OpenFOAM_SRC}/Pstream/mpi
+    ${OpenFOAM_SRC}/meshTools/lnInclude
     ${dfcantera_inc}
     ${dfchemistry_inc}
     ${dfcombustion_inc}
-    ${CANTERA_ROOT}/include 
+    ${CANTERA_ROOT}/include
     ${MPI_INCLUDE_PATH}
     ${PROJECT_SOURCE_DIR}
 )
@@ -89,8 +89,8 @@ include_directories(
 # add execution
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/dfHighSpeedFoam.C)
 
-target_link_libraries(${PROJECT_NAME} 
-    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so 
+target_link_libraries(${PROJECT_NAME}
+    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so
     libturbulenceModels.so libsampling.so libOpenFOAM.so libdynamicFvMesh.so libtopoChangerFvMesh.so
     ${CANTERA_ROOT}/lib/libcantera_shared.so.2
     ${DF_ROOT}/lib/libdfChemistryModel.so
@@ -103,14 +103,9 @@ target_link_libraries(${PROJECT_NAME}
 
 if(DEFINED ENV{PYTHON_INC_DIR})
   add_definitions(-DUSE_PYTORCH)
-  find_package (Python REQUIRED COMPONENTS Interpreter Development)
+  # https://pybind11.readthedocs.io/en/stable/advanced/embedding.html
   find_package(pybind11)
-  include_directories(
-  ${Python_INCLUDE_DIRS}
-  ${pybind11_INCLUDE_DIR}/pybind11
-  )
-  target_link_libraries(${PROJECT_NAME} ${Python_LIBRARIES})
-  message(STATUS "pybind libraries" ${Python_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME} pybind11::embed)
 endif()
 
 # install

--- a/applications/solvers/dfHighSpeedFoam/Make/options
+++ b/applications/solvers/dfHighSpeedFoam/Make/options
@@ -7,21 +7,21 @@ EXE_INC = -std=c++17 \
     $(PFLAGS) $(PINC) \
     $(if $(LIBTORCH_ROOT),-DUSE_LIBTORCH,) \
     $(if $(PYTHON_INC_DIR),-DUSE_PYTORCH,) \
-    -I$(FOAM_APP)/solvers/compressible/rhoCentralFoam/BCs/lnInclude \
-    -I$(LIB_SRC)/finiteVolume/cfdTools \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/transportModels/compressible/lnInclude \
-    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
-    -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
-    -I$(LIB_SRC)/sampling/lnInclude \
-    -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
-    -I$(LIB_SRC)/Pstream/mpi \
-    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(CANTERA_ROOT)/include \
     -I$(DF_SRC)/dfCanteraMixture/lnInclude \
     -I$(DF_SRC)/dfChemistryModel/lnInclude \
     -I$(DF_SRC)/dfCombustionModels/lnInclude \
-    -I$(CANTERA_ROOT)/include \
+    -I$(FOAM_APP)/solvers/compressible/rhoCentralFoam/BCs/lnInclude \
+    -I$(LIB_SRC)/dynamicFvMesh/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/cfdTools \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/Pstream/mpi \
+    -I$(LIB_SRC)/sampling/lnInclude \
+    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
+    -I$(LIB_SRC)/transportModels/compressible/lnInclude \
+    -I$(LIB_SRC)/TurbulenceModels/compressible/lnInclude \
+    -I$(LIB_SRC)/TurbulenceModels/turbulenceModels/lnInclude \
     $(if $(LIBTORCH_ROOT),-I$(LIBTORCH_ROOT)/include,) \
     $(if $(LIBTORCH_ROOT),-I$(LIBTORCH_ROOT)/include/torch/csrc/api/include,) \
     $(PYTHON_INC_DIR)
@@ -45,5 +45,4 @@ EXE_LIBS = \
     $(if $(LIBTORCH_ROOT),-rdynamic,) \
     $(if $(LIBTORCH_ROOT),-lpthread,) \
     $(if $(LIBTORCH_ROOT),$(DF_SRC)/dfChemistryModel/DNNInferencer/build/libDNNInferencer.so,) \
-    $(if $(PYTHON_LIB_DIR),-L$(PYTHON_LIB_DIR),) \
-    $(if $(PYTHON_LIB_DIR),-lpython3.8,)
+    $(if $(PYTHON_LIB_DIR),$(PYTHON_LIB_DIR),)

--- a/applications/solvers/dfLowMachFoam/CMakeLists.txt
+++ b/applications/solvers/dfLowMachFoam/CMakeLists.txt
@@ -16,7 +16,7 @@ if(DEFINED ENV{CANTERA_ROOT})
   SET(CANTERA_ROOT $ENV{CANTERA_ROOT})
 else()
 	message(FATAL_ERROR "libcantera directory is not specified")
-endif(DEFINED ENV{CANTERA_ROOT}) 
+endif(DEFINED ENV{CANTERA_ROOT})
 
 # define variables
 SET(OpenFOAM_LIB_DIR $ENV{FOAM_LIBBIN})
@@ -33,11 +33,11 @@ SET (CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
 
 SET(CMAKE_C_COMPILER g++)
 SET(PATH_LIB_OPENMPI "openmpi-system")  # Foundation version
-SET(EXE_COMPILE_OPTION "-std=c++11 -m64 -Dlinux64 -DWM_ARCH_OPTION=64 
--DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor 
--Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3  
--DNoRepository -ftemplate-depth-100 -std=c++14 
--Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX  
+SET(EXE_COMPILE_OPTION "-std=c++17 -m64 -Dlinux64 -DWM_ARCH_OPTION=64
+-DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor
+-Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3
+-DNoRepository -ftemplate-depth-100
+-Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX
 -pthread -fPIC")
 add_definitions("${EXE_COMPILE_OPTION}")
 
@@ -71,20 +71,20 @@ include_directories(
     ${OpenFOAM_SRC}/finiteVolume/lnInclude
     ${OpenFOAM_SRC}/OSspecific/POSIX/lnInclude
     ${OpenFOAM_SRC}/OpenFOAM/lnInclude
-    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/finiteVolume/cfdTools 
-    ${OpenFOAM_SRC}/finiteVolume/lnInclude 
-    ${OpenFOAM_SRC}/meshTools/lnInclude 
-    ${OpenFOAM_SRC}/sampling/lnInclude 
-    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude 
-    ${OpenFOAM_SRC}/Pstream/mpi 
+    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/finiteVolume/cfdTools
+    ${OpenFOAM_SRC}/finiteVolume/lnInclude
+    ${OpenFOAM_SRC}/meshTools/lnInclude
+    ${OpenFOAM_SRC}/sampling/lnInclude
+    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude
+    ${OpenFOAM_SRC}/Pstream/mpi
     ${dfcantera_inc}
     ${dfchemistry_inc}
     ${dfcombustion_inc}
-    ${CANTERA_ROOT}/include 
+    ${CANTERA_ROOT}/include
     ${MPI_INCLUDE_PATH}
     ${PROJECT_SOURCE_DIR}
     ${CUDA_INCLUDE_DIRS}
@@ -95,9 +95,9 @@ include_directories(
 # add execution
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/dfLowMachFoam.C)
 
-target_link_libraries(${PROJECT_NAME} 
-    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so 
-    libturbulenceModels.so libsampling.so libOpenFOAM.so 
+target_link_libraries(${PROJECT_NAME}
+    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so
+    libturbulenceModels.so libsampling.so libOpenFOAM.so
     ${CANTERA_ROOT}/lib/libcantera_shared.so.2
     ${DF_ROOT}/lib/libdfChemistryModel.so
     ${DF_ROOT}/lib/libdfCanteraMixture.so
@@ -111,14 +111,10 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 if(DEFINED ENV{PYTHON_INC_DIR})
-    add_definitions(-DUSE_PYTORCH)
-    find_package (Python REQUIRED COMPONENTS Interpreter Development)
-    find_package(pybind11)
-    include_directories(
-    ${Python_INCLUDE_DIRS}
-    ${pybind11_INCLUDE_DIR}/pybind11
-    )
-    target_link_libraries(${PROJECT_NAME} ${Python_LIBRARIES})
+  add_definitions(-DUSE_PYTORCH)
+  # https://pybind11.readthedocs.io/en/stable/advanced/embedding.html
+  find_package(pybind11)
+  target_link_libraries(${PROJECT_NAME} pybind11::embed)
 endif()
 
 # install

--- a/applications/solvers/dfLowMachFoam/Make/options
+++ b/applications/solvers/dfLowMachFoam/Make/options
@@ -49,9 +49,7 @@ EXE_LIBS = \
     $(if $(LIBTORCH_ROOT),-rdynamic,) \
     $(if $(LIBTORCH_ROOT),-lpthread,) \
     $(if $(LIBTORCH_ROOT),$(DF_SRC)/dfChemistryModel/DNNInferencer/build/libDNNInferencer.so,) \
-    $(if $(PYTHON_LIB_DIR),-L$(PYTHON_LIB_DIR),) \
-    $(if $(PYTHON_LIB_DIR),-lpython3.8,) \
+    $(if $(PYTHON_LIB_DIR),$(PYTHON_LIB_DIR),) \
     $(if $(AMGX_DIR), /usr/local/cuda-11.6/lib64/libcudart.so,) \
     $(if $(AMGX_DIR), $(DF_ROOT)/src_gpu/build/libdfMatrix.so,) \
     $(if $(AMGX_DIR), $(AMGX_DIR)/build/libamgxsh.so,)
-

--- a/applications/solvers/dfSprayFoam/CMakeLists.txt
+++ b/applications/solvers/dfSprayFoam/CMakeLists.txt
@@ -14,7 +14,7 @@ if(DEFINED ENV{CANTERA_ROOT})
   SET(CANTERA_ROOT $ENV{CANTERA_ROOT})
 else()
 	message(FATAL_ERROR "libcantera directory is not specified")
-endif(DEFINED ENV{CANTERA_ROOT}) 
+endif(DEFINED ENV{CANTERA_ROOT})
 
 # define variables
 SET(OpenFOAM_LIB_DIR $ENV{FOAM_LIBBIN})
@@ -29,11 +29,11 @@ SET(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=bfd -Xlinker --add-needed -Xlinker --no-as-
 
 SET(CMAKE_C_COMPILER g++)
 SET(PATH_LIB_OPENMPI "openmpi-system")  # Foundation version
-SET(EXE_COMPILE_OPTION "-std=c++11 -m64 -Dlinux64 -DWM_ARCH_OPTION=64 
--DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor 
--Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3  
--DNoRepository -ftemplate-depth-100 -std=c++14 
--Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX  
+SET(EXE_COMPILE_OPTION "-std=c++17 -m64 -Dlinux64 -DWM_ARCH_OPTION=64
+-DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor
+-Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O3
+-DNoRepository -ftemplate-depth-100
+-Wno-unused-variable -Wno-unused-but-set-variable -Wno-old-style-cast -DOMPI_SKIP_MPICXX
 -pthread -fPIC")
 add_definitions("${EXE_COMPILE_OPTION}")
 
@@ -66,31 +66,31 @@ include_directories(
     ${OpenFOAM_SRC}/finiteVolume/lnInclude
     ${OpenFOAM_SRC}/OSspecific/POSIX/lnInclude
     ${OpenFOAM_SRC}/OpenFOAM/lnInclude
-    ${OpenFOAM_SRC}/finiteVolume/lnInclude 
-    ${OpenFOAM_SRC}/meshTools/lnInclude 
-    ${OpenFOAM_SRC}/sampling/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude 
-    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/regionModels/regionModel/lnInclude 
-    ${OpenFOAM_SRC}/regionModels/surfaceFilmModels/lnInclude 
-    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude 
-    ${OpenFOAM_SRC}/meshTools/lnInclude 
-    ${OpenFOAM_SRC}/lagrangian/basic/lnInclude 
+    ${OpenFOAM_SRC}/finiteVolume/lnInclude
+    ${OpenFOAM_SRC}/meshTools/lnInclude
+    ${OpenFOAM_SRC}/sampling/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/turbulenceModels/lnInclude
+    ${OpenFOAM_SRC}/TurbulenceModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/regionModels/regionModel/lnInclude
+    ${OpenFOAM_SRC}/regionModels/surfaceFilmModels/lnInclude
+    ${OpenFOAM_SRC}/dynamicFvMesh/lnInclude
+    ${OpenFOAM_SRC}/meshTools/lnInclude
+    ${OpenFOAM_SRC}/lagrangian/basic/lnInclude
     ${dflagrangianinter_inc}
-    ${OpenFOAM_SRC}/lagrangian/intermediate/lnInclude 
-    ${dflagrangianspray_inc} 
-    ${OpenFOAM_SRC}/lagrangian/spray/lnInclude 
-    ${OpenFOAM_SRC}/lagrangian/distributionModels/lnInclude 
-    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude 
-    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude 
-    ${dfthermophysicalprop_inc} 
-    ${OpenFOAM_SRC}/thermophysicalModels/thermophysicalProperties/lnInclude 
-    ${dfthermophysicalslg_inc} 
+    ${OpenFOAM_SRC}/lagrangian/intermediate/lnInclude
+    ${dflagrangianspray_inc}
+    ${OpenFOAM_SRC}/lagrangian/spray/lnInclude
+    ${OpenFOAM_SRC}/lagrangian/distributionModels/lnInclude
+    ${OpenFOAM_SRC}/transportModels/compressible/lnInclude
+    ${OpenFOAM_SRC}/thermophysicalModels/basic/lnInclude
+    ${dfthermophysicalprop_inc}
+    ${OpenFOAM_SRC}/thermophysicalModels/thermophysicalProperties/lnInclude
+    ${dfthermophysicalslg_inc}
     ${dfcantera_inc}
     ${dfchemistry_inc}
-    ${dfcombustion_inc} 
+    ${dfcombustion_inc}
     ${OpenFOAM_SRC}/Pstream/mpi
-    ${CANTERA_ROOT}/include 
+    ${CANTERA_ROOT}/include
     ${MPI_INCLUDE_PATH}
     ${PROJECT_SOURCE_DIR}
 )
@@ -99,7 +99,7 @@ include_directories(
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/dfSprayFoam.C)
 
 target_link_libraries(${PROJECT_NAME}
-    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so libturbulenceModels.so 
+    $ENV{FOAM_LIBBIN}/libfiniteVolume.so libmeshTools.so libcompressibleTransportModels.so libturbulenceModels.so
     libsampling.so libOpenFOAM.so libdynamicFvMesh.so liblagrangian.so libregionModels.so
     ${CANTERA_ROOT}/lib/libcantera_shared.so.2
     ${DF_ROOT}/lib/libdfChemistryModel.so
@@ -116,14 +116,10 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 if(DEFINED ENV{PYTHON_INC_DIR})
-    add_definitions(-DUSE_PYTORCH)
-    find_package (Python REQUIRED COMPONENTS Interpreter Development)
-    find_package(pybind11)
-    include_directories(
-    ${Python_INCLUDE_DIRS}
-    ${pybind11_INCLUDE_DIR}/pybind11
-    )
-    target_link_libraries(${PROJECT_NAME} ${Python_LIBRARIES})
+  add_definitions(-DUSE_PYTORCH)
+  # https://pybind11.readthedocs.io/en/stable/advanced/embedding.html
+  find_package(pybind11)
+  target_link_libraries(${PROJECT_NAME} pybind11::embed)
 endif()
 
 # install

--- a/applications/solvers/dfSprayFoam/Make/options
+++ b/applications/solvers/dfSprayFoam/Make/options
@@ -67,5 +67,4 @@ EXE_LIBS = \
     $(if $(LIBTORCH_ROOT),-rdynamic,) \
     $(if $(LIBTORCH_ROOT),-lpthread,) \
     $(if $(LIBTORCH_ROOT),$(DF_SRC)/dfChemistryModel/DNNInferencer/build/libDNNInferencer.so,) \
-    $(if $(PYTHON_LIB_DIR),-L$(PYTHON_LIB_DIR),) \
-    $(if $(PYTHON_LIB_DIR),-lpython3.8,)
+    $(if $(PYTHON_LIB_DIR),$(PYTHON_LIB_DIR),)

--- a/configure.sh
+++ b/configure.sh
@@ -143,10 +143,7 @@ if [ $USE_PYTORCH = true ]; then
     if [ -z "$PYTORCH_INC" ]; then
         return
     fi
-    PYTORCH_LIB=`python3 -c "from distutils import sysconfig; \
-    import os.path as op; v = sysconfig.get_config_vars(); \
-    fpaths = [op.join(v[pv], v['LDLIBRARY']) for pv in ('LIBDIR', 'LIBPL')]; \
-    print(list(filter(op.exists, fpaths))[0])" | xargs dirname`
+    PYTORCH_LIB=`pkg-config --libs python3-embed`
 fi
 
 

--- a/docs/source/qs/install.rst
+++ b/docs/source/qs/install.rst
@@ -42,7 +42,7 @@ Alternatively, one can `compile OpenFOAM-7 from source code<https://openfoam.org
 .. code-block:: bash
     # For CUDA-supported platforms
     conda create -n deepflame \
-	pytorch torchvision torchaudio libcantera-devel easydict pybind11 \
+	pytorch torchvision torchaudio libcantera-devel easydict pybind11 pkg-config \
 	-c pytorch -c nvidia -c cantera -c conda-forge
     conda activate deepflame
 

--- a/docs/source/qs/install.rst
+++ b/docs/source/qs/install.rst
@@ -22,7 +22,7 @@ OpenFOAM-7 and ParaView-5.6.0 will be installed in the ``/opt`` directory.
 
 .. Note:: There is a commonly seen issue when installing OpenFOAM via ``apt-get install`` with an error message: ``could not find a distribution template for Ubuntu/focal``. To resolve this issue, you can refer to `issue#54 <https://github.com/deepmodeling/deepflame-dev/issues/54>`_.
 
-Alternatively, one can `compile OpenFOAM-7 from source code<https://openfoam.org/download/source/>`_.
+Alternatively, one can `compile OpenFOAM-7 from source code <https://openfoam.org/download/source/>`_.
 
 .. code-block:: bash
 
@@ -39,7 +39,7 @@ Alternatively, one can `compile OpenFOAM-7 from source code<https://openfoam.org
 
 **LibCantera** and **PyTorch** can be easily installed via `conda <https://docs.conda.io/en/latest/miniconda.html#linux-installers>`_. If your platform is compatible, run the following command to install the dependencies.
 
-.. Note:: Please go to `the official website of PyTorch<https://pytorch.org/>`_ to check your system compatibility and choose the installation command line that is suitable for your platform.
+.. Note:: Please go to `the official website of PyTorch <https://pytorch.org/>`_ to check your system compatibility and choose the installation command line that is suitable for your platform.
 
 .. code-block:: bash
 

--- a/docs/source/qs/install.rst
+++ b/docs/source/qs/install.rst
@@ -11,6 +11,7 @@ First, install OpenFOAM-7.
 .. Note:: For `Ubuntu 20.04 <https://releases.ubuntu.com/focal/>`_, one can install by ``apt``. For latest versions, please compile OpenFOAM-7 from source code. Check operating system version by ``lsb_release -d``.
 
 .. code-block:: bash
+
     # Install OpenFOAM release by apt
     sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
     sudo add-apt-repository http://dl.openfoam.org/ubuntu
@@ -24,6 +25,7 @@ OpenFOAM-7 and ParaView-5.6.0 will be installed in the ``/opt`` directory.
 Alternatively, one can `compile OpenFOAM-7 from source code<https://openfoam.org/download/source/>`_.
 
 .. code-block:: bash
+
     gcc --version
     sudo apt-get install build-essential cmake git ca-certificates
     sudo apt-get install flex libfl-dev bison zlib1g-dev libboost-system-dev libboost-thread-dev libopenmpi-dev openmpi-bin gnuplot libreadline-dev libncurses-dev libxt-dev
@@ -40,6 +42,7 @@ Alternatively, one can `compile OpenFOAM-7 from source code<https://openfoam.org
 .. Note:: Please go to `the official website of PyTorch<https://pytorch.org/>`_ to check your system compatibility and choose the installation command line that is suitable for your platform.
 
 .. code-block:: bash
+
     # For CUDA-supported platforms
     conda create -n deepflame \
 	pytorch torchvision torchaudio libcantera-devel easydict pybind11 pkg-config \

--- a/docs/source/qs/install.rst
+++ b/docs/source/qs/install.rst
@@ -5,34 +5,46 @@ Prerequisites
 ------------------------
 The installation of DeepFlame is simple and requires **OpenFOAM-7**, **LibCantera**, and **PyTorch**.
 
-.. Note:: If Ubuntu is used as the subsystem, please use `Ubuntu:20.04 <https://releases.ubuntu.com/focal/>`_ instead of the latest version. OpenFOAM-7 accompanied by ParaView 5.6.0 is not available for `Ubuntu-latest <https://releases.ubuntu.com/jammy/>`_.  
 
-First install OpenFOAM-7 if it is not already installed. 
+First, install OpenFOAM-7.
+
+.. Note:: For `Ubuntu 20.04 <https://releases.ubuntu.com/focal/>`_, one can install by ``apt``. For latest versions, please compile OpenFOAM-7 from source code. Check operating system version by ``lsb_release -d``.
 
 .. code-block:: bash
-
+    # Install OpenFOAM release by apt
     sudo sh -c "wget -O - https://dl.openfoam.org/gpg.key | apt-key add -"
     sudo add-apt-repository http://dl.openfoam.org/ubuntu
     sudo apt-get update
     sudo apt-get -y install openfoam7
 
-OpenFOAM-7 and ParaView-5.6.0 will be installed in the ``/opt`` directory. 
+OpenFOAM-7 and ParaView-5.6.0 will be installed in the ``/opt`` directory.
 
 .. Note:: There is a commonly seen issue when installing OpenFOAM via ``apt-get install`` with an error message: ``could not find a distribution template for Ubuntu/focal``. To resolve this issue, you can refer to `issue#54 <https://github.com/deepmodeling/deepflame-dev/issues/54>`_.
 
-**LibCantera** and **PyTorch** can be easily installed via `conda <https://docs.conda.io/en/latest/miniconda.html#linux-installers>`_. If you have compatible platform, run the following command to install DeepFlame.
+Alternatively, one can `compile OpenFOAM-7 from source code<https://openfoam.org/download/source/>`_.
 
 .. code-block:: bash
+    gcc --version
+    sudo apt-get install build-essential cmake git ca-certificates
+    sudo apt-get install flex libfl-dev bison zlib1g-dev libboost-system-dev libboost-thread-dev libopenmpi-dev openmpi-bin gnuplot libreadline-dev libncurses-dev libxt-dev
+    cd $HOME # the path OpenFOAM will be installed
+    wget -O - http://dl.openfoam.org/source/7 | tar xz
+    wget -O - http://dl.openfoam.org/third-party/7 | tar xz
+    mv OpenFOAM-7-version-7 OpenFOAM-7
+    mv ThirdParty-7-version-7 ThirdParty-7
+    source OpenFOAM-7/etc/bashrc
+    ./OpenFOAM-7/Allwmake -j
 
-    conda create -n deepflame python=3.8
+**LibCantera** and **PyTorch** can be easily installed via `conda <https://docs.conda.io/en/latest/miniconda.html#linux-installers>`_. If your platform is compatible, run the following command to install the dependencies.
+
+.. Note:: Please go to `the official website of PyTorch<https://pytorch.org/>`_ to check your system compatibility and choose the installation command line that is suitable for your platform.
+
+.. code-block:: bash
+    # For CUDA-supported platforms
+    conda create -n deepflame \
+	pytorch torchvision torchaudio libcantera-devel easydict pybind11 \
+	-c pytorch -c nvidia -c cantera -c conda-forge
     conda activate deepflame
-    conda install -c cantera libcantera-devel
-    conda install pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch -c nvidia
-    conda install pybind11 
-    conda install -c conda-forge easydict
-
-
-.. Note:: Please go to PyTorch's official website to check your system compatability and choose the installation command line that is suitable for your platform.  
 
 .. Note:: Check your ``Miniconda3/envs/deepflame`` directory and make sure the install was successful (lib/ include/ etc. exist).
 
@@ -41,13 +53,13 @@ Configure
 -------------------------
 **1. Source your OpenFOAM-7 bashrc to configure the $FOAM environment.**
 
-.. Note:: This depends on your own path for OpenFOAM-7 bashrc.  
+.. Note:: This depends on your own path for OpenFOAM-7 bashrc.
 
 If you have installed using ``apt-get install``, then:
 
 .. code-block:: bash
 
-    source /opt/openfoam7/etc/bashrc 
+    source /opt/openfoam7/etc/bashrc
 
 If you compiled from source following the `official guide <https://openfoam.org/download/7-source/>`_, then:
 
@@ -66,7 +78,7 @@ or
 .. code-block:: bash
 
      echo "source $HOME/OpenFOAM/OpenFOAM-7/etc/bashrc" >> ~/.bashrc
-    
+
 Then source the bashrc file by:
 
 .. code-block:: bash
@@ -87,13 +99,13 @@ If you want to use the submodules included in DeepFlame: the `WENO scheme <https
 
     git clone --recursive https://github.com/deepmodeling/deepflame-dev.git
 
-Detailed instructions for compiling these two submodules can be found in their original repositories. 
+Detailed instructions for compiling these two submodules can be found in their original repositories.
 
 
 **3. Configure the DeepFlame environment:**
 
 .. code-block:: bash
-    
+
     cd deepflame-dev
     . configure.sh --use_pytorch
     source ./bashrc
@@ -102,14 +114,14 @@ Detailed instructions for compiling these two submodules can be found in their o
 
 Build and Install
 -------------------------------
-Finally you can build and install DeepFlame: 
+Finally you can build and install DeepFlame:
 
 .. code-block:: bash
 
-    . install.sh  
+    . install.sh
 
 .. Note:: You may come accross an error regarding shared library ``libmkl_rt.so.2`` when libcantera is installed through cantera channel. If so, go to your conda environment and check the existance of ``libmkl_rt.so.2`` and ``libmkl_rt.so.1``, and then link ``libmkl_rt.so.2`` to ``libmkl_rt.so.1``.
-    
+
 .. code-block:: bash
 
     cd ~/miniconda3/envs/deepflame/lib
@@ -121,10 +133,10 @@ Finally you can build and install DeepFlame:
 
 Other Options
 -------------------------------
-DeepFlame also provides users with LibTorch and CVODE (no DNN version) options. 
+DeepFlame also provides users with LibTorch and CVODE (no DNN version) options.
 
 **1. If you choose to use LibTorch (C++ API for Torch), first create the conda env and install** `LibCantera <https://anaconda.org/conda-forge/libcantera-devel>`_:
-    
+
 .. code-block:: bash
 
     conda create -n df-libtorch python=3.8
@@ -156,11 +168,11 @@ If the conda env ``df-notorch`` is activated, install DeepFlame by running:
 .. code-block:: bash
 
     cd deepflame-dev
-    . configure.sh 
+    . configure.sh
     source ./bashrc
     . install.sh
 
-If ``df-notorch`` not activated (or you have a self-complied libcantera), specify the path to your libcantera:
+If ``df-notorch`` not activated (or you have a self-compiled libcantera), specify the path to your libcantera:
 
 .. code-block:: bash
 
@@ -182,7 +194,7 @@ To begin, you will need to install AMGX. You can find the instructions for insta
     source ./bashrc
     . install.sh
 
-Also, you will need to add configuration files for AMGX for each euqation under ``system`` folder and name them in the pattern of ``amgxpOptions``, ``amgxUOptions`` . Please refer to the AMGX official website to find out detailed instructions. 
+Also, you will need to add configuration files for AMGX for each euqation under ``system`` folder and name them in the pattern of ``amgxpOptions``, ``amgxUOptions`` . Please refer to the AMGX official website to find out detailed instructions.
 
 **If you have compiled DeepFlame with GPU solver successfully, you should see the print message in your terminal:**
 
@@ -201,7 +213,7 @@ Also, you will need to add configuration files for AMGX for each euqation under 
 You will need to follow the same procedures to install prerequisites and configure DeepFlame.
 
 .. code-block:: bash
-    
+
     cd deepflame-dev
     . configure.sh --use_pytorch
     source ./bashrc
@@ -216,7 +228,7 @@ After this, first install libraries:
     cd build
     make install
 
-Now if go to ``$DF_ROOT/lib``, libraries should be ready. 
+Now if go to ``$DF_ROOT/lib``, libraries should be ready.
 Compilition of solvers are separated. Choose the solver you want to use and then go to the directory and build it. For example,
 
 
@@ -226,4 +238,3 @@ Compilition of solvers are separated. Choose the solver you want to use and then
     cmake -B build
     cd build
     make install
-


### PR DESCRIPTION
- Use `pkg-config --libs python3-embed` to locate python libs
- Remove the requirements for python==3.8: I successfully installed DeepFlame on latest versions of all conda packages.
- Update correct pybind11 linking path for CMake
- Update docs for installing instructions and fix typos