### PR TITLE
Improve Initialization in dfChemistryModel

### DIFF
--- a/src/dfChemistryModel/dfChemistryModel.H
+++ b/src/dfChemistryModel/dfChemistryModel.H
@@ -94,6 +94,9 @@ public IOdictionary
         CanteraMixture& mixture_;
         std::shared_ptr<Cantera::ThermoPhase> CanteraGas_;
         std::shared_ptr<Cantera::Kinetics> CanteraKinetics_;
+        std::unique_ptr<Cantera::Reactor> react_;
+        std::unique_ptr<Cantera::ReactorNet> sim_;
+
         const fvMesh& mesh_;
         Switch chemistry_;
 


### PR DESCRIPTION
## Summary

This pull request addresses the issue of repetitive initialization in the Cantera Reactor by calling `syncState()`.

## Performance Test

### Versions Tested
- **DeepFlame Version**: 
  - Commit `0d4e5ee`
  - Commit `v1.3 94c068d`

- **Test Environment**: 
  - Local machine

- **Example Used**: 
  - `deepflame-dev/examples/dfLowMachFoam/notorch/twoD_HIT_flame/CH4`

### Logs
- **0d4e5ee Log**: 
```
Time = 3e-05
========Time Spent in diffenet parts========
loop Time                    = 4.59224 s
other Time                   = 0 s
rho Equations                = 0.010025 s
U Equations                  = 0.153318 s
Y Equations                  = 2.19407 s
E Equations                  = 0.190781 s
p Equations                  = 0.451789 s
chemistry correctThermo      = 1.00366 s
turbulence correct           = 3e-06 s
combustion correct(in Y)     = 0.549414 s
percentage of chemistry      = 11.964 %
percentage of rho/U/Y/E      = 55.4891 %
```

- **v1.3 94c068d Log**: 
```
Time = 3e-05
========Time Spent in diffenet parts========
loop Time                    = 31.0999 s
other Time                   = 0 s
rho Equations                = 0.007421 s
U Equations                  = 0.164248 s
Y Equations                  = 4.28438 s
E Equations                  = 0.33561 s
p Equations                  = 0.852007 s
chemistry correctThermo      = 1.07524 s
turbulence correct           = 4e-06 s
combustion correct(in Y)     = 24.3789 s
percentage of chemistry      = 78.3891 %
percentage of rho/U/Y/E      = 15.4073 %
```